### PR TITLE
Update MathJax CDN location

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@
     <!-- Google tag (gtag.js) -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-PRVD4KMH9C"></script>
     <script>window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}   gtag('js', new Date());   gtag('config', 'G-PRVD4KMH9C');</script>
-    <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
   </head>
   <body class="bg-gunmetal-50 text-charcoal dark:bg-gunmetal-950 dark:text-charcoal-100">
     <!-- NAVIGATION -->


### PR DESCRIPTION
Fixes a warning shown in the console on loading the site. The old link was already re-directing to this location.