### PR TITLE
Update tech-carbon-estimator version to support dark mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,8 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "Technology-Carbon-Standard",
       "devDependencies": {
-        "@scottlogic/tech-carbon-estimator": "^0.0.1",
+        "@scottlogic/tech-carbon-estimator": "^0.0.2",
         "@tailwindcss/typography": "^0.5.10",
         "autoprefixer": "^10.4.17",
         "cssnano": "^6.0.3",
@@ -314,9 +313,9 @@
       }
     },
     "node_modules/@scottlogic/tech-carbon-estimator": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@scottlogic/tech-carbon-estimator/-/tech-carbon-estimator-0.0.1.tgz",
-      "integrity": "sha512-fb447g0v/k0sR8X3kvlKXnSILKS0L+UpyB5Kwexd4HLuIJaJIpIyh257qU6WeauGhcXZQgi0Sn1JbxF9iQiGqA==",
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@scottlogic/tech-carbon-estimator/-/tech-carbon-estimator-0.0.2.tgz",
+      "integrity": "sha512-wQ/48UTiyLyaaZEh7L/mN6eTeBjhBWu3PRb/xc7y70pXVFBofVDsvWvCAQ6azug91jwzKkvm2PnTAhOi/kPt4g==",
       "dev": true,
       "dependencies": {
         "@angular/animations": "^17.2.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "postcss": "^8.4.33",
     "postcss-cli": "^11.0.0",
     "tailwindcss": "^3.4.1",
-    "@scottlogic/tech-carbon-estimator": "^0.0.1"
+    "@scottlogic/tech-carbon-estimator": "^0.0.2"
   }
 }


### PR DESCRIPTION
Latest version should ensure that all text has suitable contrast with its background colour.

![image](https://github.com/ScottLogic/Technology-Carbon-Standard/assets/117279304/6f40ca79-ba7f-4381-8a41-322a18bac7b7)

Version 0.0.2 also includes:

- Accessibility improvements to keyboard navigation and error messaging
- Removal of diagram on reset
- Diagram size fixes
- Updates to assumptions text