### PR TITLE
SFD-148: Improve the contrast of the sliders for dark mode view

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -20,15 +20,8 @@
   }
 
   input {
-    @apply accent-gunmetal-800
+    @apply accent-gunmetal-800 dark:accent-cambridge-300;
   }
-
-  @media (prefers-color-scheme: dark) {
-    input {
-        @apply accent-cambridge-300
-    }
-}
-
 
   /* CATEGORY U */
   .cat-u {

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -19,6 +19,10 @@
     @apply underline text-blue-600 hover:text-blue-800 focus:outline-none focus-visible:ring focus:ring-blue dark:text-blue-300 dark:hover:text-blue-100;
   }
 
+  input {
+    @apply accent-gunmetal-800
+  }
+
   @media (prefers-color-scheme: dark) {
     input {
         @apply accent-cambridge-300

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -19,6 +19,13 @@
     @apply underline text-blue-600 hover:text-blue-800 focus:outline-none focus-visible:ring focus:ring-blue dark:text-blue-300 dark:hover:text-blue-100;
   }
 
+  @media (prefers-color-scheme: dark) {
+    input {
+        @apply accent-cambridge-300
+    }
+}
+
+
   /* CATEGORY U */
   .cat-u {
     @apply bg-blue dark:bg-blue-700 text-white;


### PR DESCRIPTION
[SFD-148 Jira ticket](https://scottlogic.atlassian.net/jira/software/projects/SFD/boards/104?selectedIssue=SFD-148)

Improves the contract for the left hand side of the sliders in dark mode.

Notes:
- The colour on the right hand side of the slider is determined by the browser based on the colour we set the left hand side to and varies between them.
- I've also changed the colour of the sliders in light mode from blue to dark green to match the colour scheme of the page a bit better.

Dark mode sliders:
Chrome:
![dark-mode-slider-chrome](https://github.com/user-attachments/assets/cb5542fa-3bc7-49f0-89df-e7ed2a59790e)

Firefox:
![dark-mode-slider-firefox](https://github.com/user-attachments/assets/d36fc05e-9cb5-40b1-bb2d-c9b577cdda79)

Edge:
![dark-mode-slider-edge](https://github.com/user-attachments/assets/6f7c8fb5-7062-4eb6-89f9-16c666cb8f3a)

Light mode sliders:
Chrome:
![light-mode-slider-chrome](https://github.com/user-attachments/assets/17bb8111-11b1-418d-bb93-6ad10a03cd6c)

Firefox:
![light-mode-slider-firefox](https://github.com/user-attachments/assets/cbbe8fe7-ef03-4fcd-8f6a-0cb038da257a)

Edge:
![light-mode-slider-edge](https://github.com/user-attachments/assets/ad20b17c-7bd2-4f89-b6c4-7477f35cf4c3)
