### PR TITLE
Fix links between gwf case study pages

### DIFF
--- a/pages/case_studies/gwf/1-overview.md
+++ b/pages/case_studies/gwf/1-overview.md
@@ -94,7 +94,7 @@ Organisations can push suppliers to provide machine readable, publicly verifiabl
 
 Organisations can make a considerable impact on their digital estate emission estimates by choosing to minimise unnecessary hardware and use what they do need efficiently. Procurement departments can prioritise refurbed, remanufactured or reused employee hardware and shortly, consider the ecodesign ratings on specific product groups. As an added bonus, organisations can also choose to support non-profit campaign groups like [repair.eu](https://repair.eu/).
 
-[Insights full write-up](Insights)
+[Insights full write-up](/case-studies/green-web-foundation/insights)
 
 [To the top](#top)
 
@@ -153,5 +153,5 @@ The project set out to use the TCS framework to estimate GWF's digital estate, f
 [To the top](#top)
 
 ---
-[Next - Insights](Insights)
+[Next - Insights](/case-studies/green-web-foundation/insights)
 

--- a/pages/case_studies/gwf/2-insights.md
+++ b/pages/case_studies/gwf/2-insights.md
@@ -39,11 +39,11 @@ _Quick note: When you see words like "we" and "us" in this section, please assum
 
 **The findings**
 
-There's still a prevalent misconception that the digital technologies sector is green by default, and there's no carbon impact associated with using digital tools. Check the appendix for our [insight into why we think that might be](appendix/#green-by-default).
+There's still a prevalent misconception that the digital technologies sector is green by default, and there's no carbon impact associated with using digital tools. Check the appendix for our [insight into why we think that might be](/case-studies/green-web-foundation/appendix/#green-by-default).
 
 But we're starting to know better. There are now examples of organisations having a go at estimating their overall impact from digital, and for many it's surprising. Recent studies by digitally-enabled service based organisations, like [Salesforce](https://podcast.greensoftware.foundation/e/vnwrkjm8-the-week-in-green-software-net-zero-cloud) and [ABN Amro](https://www.abnamro.com/en/information/sustainability-reporting-and-publications?selectedTabs=Reporting), estimate that digital accounts for 40 - 50% of their organisation’s greenhouse gas emissions. Scott Logic's [2023 Environmental Impact Report](https://www.scottlogic.com/news/making-good-progress-towards-net-zero) details their digital emissions for the first time estimated at 158 tonnes CO<sub>2</sub>e, 15% of their organisation's total.
 
-Our own 2023 digital estate emissions are [_at least_ 496 kgCO<sub>2</sub>e](overview#estimates-summary). To put this figure into perspective it's estimated the average cow raised for beef in Scotland emits around [2,600 kgCO<sub>2</sub>e per year](https://www.gov.scot/publications/resas-climate-change-evidence-dairy-farmer-led-group/pages/3/). An economy class return flight from [London to Berlin is 523 kgCO<sub>2</sub>](https://co2.myclimate.org/en/portfolios?calculation_id=7289065). If taken in isolation, you might continue to conclude that the digital impact is too small work on. But there are a couple of key things to bear in mind.
+Our own 2023 digital estate emissions are [_at least_ 496 kgCO<sub>2</sub>e](/case-studies/green-web-foundation/overview#estimates-summary). To put this figure into perspective it's estimated the average cow raised for beef in Scotland emits around [2,600 kgCO<sub>2</sub>e per year](https://www.gov.scot/publications/resas-climate-change-evidence-dairy-farmer-led-group/pages/3/). An economy class return flight from [London to Berlin is 523 kgCO<sub>2</sub>](https://co2.myclimate.org/en/portfolios?calculation_id=7289065). If taken in isolation, you might continue to conclude that the digital impact is too small work on. But there are a couple of key things to bear in mind.
 
 **We're very small.** We're a six person team operating a lean non-profit organisation, with a relatively straightforward set of digital products. We'd expect our emissions estimate to be small. Unfortunately we haven't done the rest of our 2023 emissions reporting yet to understand the relative percentage of that. But our napkin based figures suggest it'll be less than 10%, and that's mainly due to our travel.
 
@@ -67,7 +67,7 @@ We recognise that making changes to our own practices is easier for us compared 
 
 **The findings**
 
-When we set [our goal to estimate GWF's emissions for 2023](overview#context---why-this-project) we reviewed what [solutions for small businesses existed](https://ib1.org/ecosystem/2024-carbon-reporting-solutions-report/) (thanks Icebreaker One!). Looking at how the most popular SaaS tools approached producing _digital estate_ estimates, we saw that the methodologies revolved around using financial spend as the key metric. But frustratingly these approaches seemed opaque beyond the high level.
+When we set [our goal to estimate GWF's emissions for 2023](/case-studies/green-web-foundation/overview#context---why-this-project) we reviewed what [solutions for small businesses existed](https://ib1.org/ecosystem/2024-carbon-reporting-solutions-report/) (thanks Icebreaker One!). Looking at how the most popular SaaS tools approached producing _digital estate_ estimates, we saw that the methodologies revolved around using financial spend as the key metric. But frustratingly these approaches seemed opaque beyond the high level.
 
 We know from our own experience that spend based metrics are best viewed as a starting point. They're riddled with problems and don't lend any meaningful assistance when considering how to reduce impact as many commercial models rely on free, or reduced, offerings. We felt there's enough research out there by now that we can make the next iteration forward and improve upon this. Whilst, of course, still embracing the concept of [progress over perfection](https://branch.climateaction.tech/issues/issue-8/).
 
@@ -174,7 +174,7 @@ The **longer answer** is that we recognise there are a multitude of ways you can
 - The 342 kgCO<sub>2</sub>e/year figure comes from a snapshot in time. 2023 turns out to be a year that GWF ended up bearing responsibility for the emissions of four purchased machines (two refurbed and two new), but no monitor purchases. Is this an average year or an outlier? We can't know confidently until we estimate GWF's digital estate for a few more years.
 - The 342 kgCO<sub>2</sub>e/year figure itself is only an estimate. The accuracy of any estimate should always be viewed with a pinch of salt. It is not a precise measurement. However, we rated the methodologies we used for the two largest parts of this calculation with high confidence. The third methodology with medium confidence. Is there room for improvement in these methodologies? Absolutely. Is there room for improvement in the [PCF](/resources/glossary#product-carbon-footprint-pcf) datasheets produced, or in many cases not produced, by hardware manufacturers? Absolutely. _(Looking at you printer manufacturers.)_
 
-What's really noteworthy about this section is the impact that buying refurbed, remanufactured or reused hardware has on estimates. [We modelled the impact of our laptop choices](reducing-impact#employee-hardware) and found that simply by choosing a refurbed machine over a new one, you can save nearly 85% of the carbon emissions.
+What's really noteworthy about this section is the impact that buying refurbed, remanufactured or reused hardware has on estimates. [We modelled the impact of our laptop choices](/case-studies/green-web-foundation/reducing-impact#employee-hardware) and found that simply by choosing a refurbed machine over a new one, you can save nearly 85% of the carbon emissions.
 
 Another surprise was what the numbers showed us about the impact of monitors. Again, if you'd asked the project team at the start which represented more emissions - laptops or monitors - we'd have all guessed laptops. But surprisingly the data we found shows monitors are estimated to produce more emissions on a unit by unit basis. This is true both for the embodied and usage emissions.
 
@@ -206,4 +206,4 @@ This raises an important question. What can we really do to minimize the impact 
 
 ---
 
-[Next - Assumptions](assumptions)
+[Next - Assumptions](/case-studies/green-web-foundation/assumptions)

--- a/pages/case_studies/gwf/3-assumptions.md
+++ b/pages/case_studies/gwf/3-assumptions.md
@@ -102,4 +102,4 @@ This project narrowed in on carbon emissions as a starting lens to begin underst
 Hannah, from GWF, has spoken a lot about this issue in the past. Her fellowship project, [doingthedoughnut.tech](https://doingthedoughnut.tech/), goes into this more detail.
 
 ---
-[Next - Estimating the Upstream Emissions](upstream)
+[Next - Estimating the Upstream Emissions](/case-studies/green-web-foundation/upstream)

--- a/pages/case_studies/gwf/4-upstream-emissions.md
+++ b/pages/case_studies/gwf/4-upstream-emissions.md
@@ -120,7 +120,7 @@ To keep things simple for this high-level estimate we assumed the following:
 - All employees used non-manufacturer specific laptops at this point - we weren't ready to get a detailed equipment list at this point.
 - All laptops were purchased new - we ignored the fact that some machines were actually refurbished, older or second-hand.
 - A laptop's expected life is 5 years at GWF (industry standard is often cited as 4 years). 
-- [Amortisation](/resources/glossary#amortisation) of embodied emissions was appropriate for a [high level estimate](assumptions#high-level-estimates) - more on this below.
+- [Amortisation](/resources/glossary#amortisation) of embodied emissions was appropriate for a [high level estimate](/case-studies/green-web-foundation/assumptions#high-level-estimates) - more on this below.
 
 For the six laptops identified, only 1 laptop is owned by GWF and the other 5 are BYODs. We attribute 100% of the embodied carbon to 1 laptop, and 70% to the other 5.
 
@@ -332,6 +332,6 @@ GWF does not own any of it's own servers or storage hardware. This means there a
 
 ---
 
-[Next - Estimating the Operational Emissions](operational)
+[Next - Estimating the Operational Emissions](/case-studies/green-web-foundation/operational)
 
 ---

--- a/pages/case_studies/gwf/5-operational-emissions.md
+++ b/pages/case_studies/gwf/5-operational-emissions.md
@@ -314,7 +314,7 @@ The scope of this section was therefore estimating GWF's usage of these two supp
 
 ### High level Estimate Methodology
 
-We used a spend-based method to estimate the high level carbon emissions. Unfortunately, we could not find specific methods for Hetzner or Scaleway. Instead, we used AWS as a proxy so that we could use the open-source spend-based model from [Cloud Carbon Footprint (CCF)](https://www.cloudcarbonfootprint.org/). We felt this was good enough to produce a [high level estimate](assumptions#high level-estimates) in order to quantify the scale of emissions.
+We used a spend-based method to estimate the high level carbon emissions. Unfortunately, we could not find specific methods for Hetzner or Scaleway. Instead, we used AWS as a proxy so that we could use the open-source spend-based model from [Cloud Carbon Footprint (CCF)](https://www.cloudcarbonfootprint.org/). We felt this was good enough to produce a [high level estimate](/case-studies/green-web-foundation/assumptions#high level-estimates) in order to quantify the scale of emissions.
 
 #### **Hetzner VMs**
 
@@ -452,7 +452,7 @@ $$ 48.05\ kWh/year \times 0.0195\ kgCO_2e/kWh = 0.94\ kgCO2_e/year $$
 
 **The resulting detailed operational carbon emissions estimate for the four Hetzner VMs is 0.94 kgCO<sub>2</sub>e/year.**
 
-We experiment with a different carbon intensity value in the [cloud services reducing impact write-up](reducing-impact#cloud-services). 
+We experiment with a different carbon intensity value in the [cloud services reducing impact write-up](/case-studies/green-web-foundation/reducing-impact#cloud-services). 
 
 To combine the embodied carbon of these servers, we need to rely on the high level methodology (without knowing the specific details of the server's embodied carbon). In this case we are specifically taking into account the four servers we have looked at in the detailed calculations above, and not the total embodied carbon of all of GWF's servers we concluded in the high level-estimate.
 
@@ -572,12 +572,12 @@ A rudimentary method is to simply divide the carbon emissions by the number of a
 
 $$ (21,0000\ MTCO_2e/year \times 1000) ÷ 7,590,000 = 2.77\ kgCO2e/year/website $$
 
-In the absense of any data whatsoever, 2.77 kgCO<sub>2</sub>e/year per website could be used an average or proxy metric to perform a [high level estimate](assumptions#high level-estimates) of CDNs.
+In the absense of any data whatsoever, 2.77 kgCO<sub>2</sub>e/year per website could be used an average or proxy metric to perform a [high level estimate](/case-studies/green-web-foundation/assumptions#high level-estimates) of CDNs.
 
 [To the top](#top)
 
 ---
 
-[Next - Estimating the Downstream Emissions](downstream)
+[Next - Estimating the Downstream Emissions](/case-studies/green-web-foundation/downstream)
 
 ---

--- a/pages/case_studies/gwf/6-downstream-emissions.md
+++ b/pages/case_studies/gwf/6-downstream-emissions.md
@@ -203,6 +203,6 @@ $$ 14\ kWh/year \times 0.490\ kgCO_2e/kWh = 6.86\ kgCO_2e/year $$
 
 ---
 
-[Next - Reducing impact](reducing-impact)
+[Next - Reducing impact](/case-studies/green-web-foundation/reducing-impact)
 
 ---

--- a/pages/case_studies/gwf/7-reducing-impact.md
+++ b/pages/case_studies/gwf/7-reducing-impact.md
@@ -25,7 +25,7 @@ In this section, we look beyond estimations/reporting and think about what facto
 
 Of the four laptops acquired in 2023, two were purchased new and two refurbished. Those refurbished laptops use a condition factor of 15% attribution, the new laptops use 100% attribution.
 
-Returning to the [formula we used in the upstream emissions section](upstream#detailed-estimate-methodology), we can recalculate the total embodied carbon emissions assuming all four laptops were acquired as new:
+Returning to the [formula we used in the upstream emissions section](/case-studies/green-web-foundation/upstream#detailed-estimate-methodology), we can recalculate the total embodied carbon emissions assuming all four laptops were acquired as new:
 
 $$ Attributed\_Carbon = Embodied\_Carbon \times Condition\_Factor \times BYOD\_Attribution\_Factor $$
 
@@ -49,7 +49,7 @@ With two refurbished and two new laptops, we previously calculated a total of 18
 
 ### Exploration
 
-Let's revisit the [detailed estimation for Hetzner VMs operational emissions](operational#hetzner-vm-detail). The resulting detailed operational carbon emissions estimate for the four Hetzner VMs was 0.94 kgCO2e/year.
+Let's revisit the [detailed estimation for Hetzner VMs operational emissions](/case-studies/green-web-foundation/operational#hetzner-vm-detail). The resulting detailed operational carbon emissions estimate for the four Hetzner VMs was 0.94 kgCO2e/year.
 
 To estimate those emissions, we used a renewable energy carbon intensity value of 0.0195 kgCO<sub>2</sub>e/kWh which represents a mix of hydro and wind power. To model our what-if scenario we can replace this carbon intensity for a region's carbon intensity. 
 
@@ -77,6 +77,6 @@ Let's bear in mind these numbers in isolation are very small, because GWF doesn'
 
 ---
 
-[Next - Appendix](appendix)
+[Next - Appendix](/case-studies/green-web-foundation/appendix)
 
 ---

--- a/pages/case_studies/gwf/8-appendix.md
+++ b/pages/case_studies/gwf/8-appendix.md
@@ -76,7 +76,7 @@ Development of the tool and the methodologies it uses to calculate the measureme
 
 ---
 
-[Next - Back to Introduction](overview)
+[Next - Back to Introduction](/case-studies/green-web-foundation/overview)
 
 ---
 

--- a/pages/case_studies/gwf/green-web-foundation.md
+++ b/pages/case_studies/gwf/green-web-foundation.md
@@ -11,11 +11,11 @@ As long-term advocates for the benefits of open-source, Green Web Foundation (GW
 
 This project write-up is the result of this collaboration.
 
-1. [Overview](overview)
-1. [Insights](insights)
-1. [Assumptions](assumptions)
-1. [Upstream Emissions](upstream)
-1. [Operational Emissions](operational)
-1. [Downstream Emissions](downstream)
-1. [Reducing impact](reducing-impact)
-1. [Appendix](appendix)
+1. [Overview](/case-studies/green-web-foundation/overview)
+1. [Insights](/case-studies/green-web-foundation/insights)
+1. [Assumptions](/case-studies/green-web-foundation/assumptions)
+1. [Upstream Emissions](/case-studies/green-web-foundation/upstream)
+1. [Operational Emissions](/case-studies/green-web-foundation/operational)
+1. [Downstream Emissions](/case-studies/green-web-foundation/downstream)
+1. [Reducing impact](/case-studies/green-web-foundation/reducing-impact)
+1. [Appendix](/case-studies/green-web-foundation/appendix)


### PR DESCRIPTION
## Description of Change

Add full path to gwf case study links. When using links with no preceding slash it appears to work correctly locally but when deployed it is missing green-web-foundation from the path, possibly something to do with the baseurl applied in the build process.