### PR TITLE
Update Tech Carbon Estimator to version to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "devDependencies": {
-        "@scottlogic/tech-carbon-estimator": "^0.6.0",
+        "@scottlogic/tech-carbon-estimator": "^0.7.0",
         "@tailwindcss/typography": "^0.5.10",
         "@types/jest": "^29.5.14",
         "ajv": "^8.17.1",
@@ -46,22 +46,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@angular/animations": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.10.tgz",
-      "integrity": "sha512-WSKHyF82URlAQkYGWZjozZgSYj2ClH40GDunayz6kuRewup639iH91HE8sbFfVqKgqELKIAy2E0LhmtDKnMwZA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "20.3.10"
-      }
-    },
     "node_modules/@angular/cdk": {
       "version": "20.2.12",
       "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-20.2.12.tgz",
@@ -84,6 +68,7 @@
       "integrity": "sha512-12fEzvKbEqjqy1fSk9DMYlJz6dF1MJVXuC5BB+oWWJpd+2lfh4xJ62pkvvLGAICI89hfM5n9Cy5kWnXwnqPZsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -95,25 +80,13 @@
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
-    "node_modules/@angular/compiler": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.10.tgz",
-      "integrity": "sha512-cW939Lr8GZjPSYfbQKIDNrUaHWmn2M+zBbERThfq5skLuY+xM60bJFv4NqBekfX6YqKLCY62ilUZlnImYIXaqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
     "node_modules/@angular/core": {
       "version": "20.3.10",
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.10.tgz",
       "integrity": "sha512-g99Qe+NOVo72OLxowVF9NjCckswWYHmvO7MgeiZTDJbTjF9tXH96dMx7AWq76/GUinV10sNzDysVW16NoAbCRQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -132,103 +105,6 @@
         "zone.js": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/elements": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular/elements/-/elements-20.3.10.tgz",
-      "integrity": "sha512-8xqd3v/e0oNPZFt35OdrXU61a4ughsNjjRgc+j9eD4u4KpLggTMBKW26hh2c6nAnqhZcH3eX6qLBx0wU3zN95w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/core": "20.3.10",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "node_modules/@angular/forms": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.10.tgz",
-      "integrity": "sha512-9yWr51EUauTEINB745AaHwZNTHLpXIm4uxuykxzOg+g2QskEgVfH26uS8G2ogdNuwYpB8wnsXWr34qhM3qgOWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "20.3.10",
-        "@angular/core": "20.3.10",
-        "@angular/platform-browser": "20.3.10",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "node_modules/@angular/platform-browser": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.10.tgz",
-      "integrity": "sha512-UV8CGoB5P3FmJciI3/I/n3L7C3NVgGh7bIlZ1BaB/qJDtv0Wq0rRAGwmT/Z3gwmrRtfHZWme7/CeQ2CYJmMyUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": "20.3.10",
-        "@angular/common": "20.3.10",
-        "@angular/core": "20.3.10"
-      },
-      "peerDependenciesMeta": {
-        "@angular/animations": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@angular/platform-browser-dynamic": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.10.tgz",
-      "integrity": "sha512-gtZPCuxfxxkMzHYBdTU9tJeTiHj+Aty3C408DJGtGU+7rZgKt9hDC14vQN9OVzB9Ly9Jwj2yr8u7AH80TxxCJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "20.3.10",
-        "@angular/compiler": "20.3.10",
-        "@angular/core": "20.3.10",
-        "@angular/platform-browser": "20.3.10"
-      }
-    },
-    "node_modules/@angular/router": {
-      "version": "20.3.10",
-      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.10.tgz",
-      "integrity": "sha512-Z03cfH1jgQ7XMDJj4R8qAGqivcvhdG3wYBwaiN1K1ODBgPhbFKNeD4stKqYp7xBNtswmM2O2jMxrL/Djwju4Gg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@angular/common": "20.3.10",
-        "@angular/core": "20.3.10",
-        "@angular/platform-browser": "20.3.10",
-        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1259,31 +1135,199 @@
       }
     },
     "node_modules/@scottlogic/tech-carbon-estimator": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@scottlogic/tech-carbon-estimator/-/tech-carbon-estimator-0.6.0.tgz",
-      "integrity": "sha512-6n0P/4V6zbAjZaBRw85W71WNZBrFpA4d6yAQEIITkMwHwsu+n3GQNjPHEZaAOG7P4x9RGXYES9PJUGXWxsZakA==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@scottlogic/tech-carbon-estimator/-/tech-carbon-estimator-0.7.0.tgz",
+      "integrity": "sha512-tlxk7ye84jaRrR2nvemZjgNFw0KMS1G5Nzrqx2wmUzsmhbq9zdPm2NsoEkReH285RihwCgC1p9yBlNDaM1En0w==",
       "dev": true,
       "dependencies": {
-        "@angular/animations": "^20.0.0",
+        "@angular/animations": "^20.3.15",
         "@angular/cdk": "^20.0.0",
-        "@angular/common": "^20.0.0",
-        "@angular/compiler": "^20.0.0",
-        "@angular/core": "^20.0.0",
-        "@angular/elements": "^20.0.0",
-        "@angular/forms": "^20.0.0",
-        "@angular/platform-browser": "^20.0.0",
-        "@angular/platform-browser-dynamic": "^20.0.0",
-        "@angular/router": "^20.0.0",
+        "@angular/common": "^20.3.15",
+        "@angular/compiler": "^20.3.15",
+        "@angular/core": "^20.3.15",
+        "@angular/elements": "^20.3.15",
+        "@angular/forms": "^20.3.15",
+        "@angular/platform-browser": "^20.3.15",
+        "@angular/platform-browser-dynamic": "^20.3.15",
+        "@angular/router": "^20.3.15",
         "@tailwindcss/postcss": "^4.1.11",
         "@tgwf/co2": "^0.16.8",
         "html2canvas-pro": "^1.5.11",
         "jspdf": "^3.0.2",
         "lodash-es": "^4.17.21",
         "ng-apexcharts": "^1.17.0",
-        "playwright": "^1.54.2",
         "rxjs": "^7.8.2",
         "tslib": "^2.8.1",
         "zone.js": "~0.15.1"
+      }
+    },
+    "node_modules/@scottlogic/tech-carbon-estimator/node_modules/@angular/animations": {
+      "version": "20.3.15",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.15.tgz",
+      "integrity": "sha512-ikyKfhkxoqQA6JcBN0B9RaN6369sM1XYX81Id0lI58dmWCe7gYfrTp8ejqxxKftl514psQO3pkW8Gn1nJ131Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "20.3.15"
+      }
+    },
+    "node_modules/@scottlogic/tech-carbon-estimator/node_modules/@angular/common": {
+      "version": "20.3.15",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.15.tgz",
+      "integrity": "sha512-k4mCXWRFiOHK3bUKfWkRQQ8KBPxW8TAJuKLYCsSHPCpMz6u0eA1F0VlrnOkZVKWPI792fOaEAWH2Y4PTaXlUHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "20.3.15",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@scottlogic/tech-carbon-estimator/node_modules/@angular/compiler": {
+      "version": "20.3.15",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.15.tgz",
+      "integrity": "sha512-lMicIAFAKZXa+BCZWs3soTjNQPZZXrF/WMVDinm8dQcggNarnDj4UmXgKSyXkkyqK5SLfnLsXVzrX6ndVT6z7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@scottlogic/tech-carbon-estimator/node_modules/@angular/core": {
+      "version": "20.3.15",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.15.tgz",
+      "integrity": "sha512-NMbX71SlTZIY9+rh/SPhRYFJU0pMJYW7z/TBD4lqiO+b0DTOIg1k7Pg9ydJGqSjFO1Z4dQaA6TteNuF99TJCNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/compiler": "20.3.15",
+        "rxjs": "^6.5.3 || ^7.4.0",
+        "zone.js": "~0.15.0"
+      },
+      "peerDependenciesMeta": {
+        "@angular/compiler": {
+          "optional": true
+        },
+        "zone.js": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@scottlogic/tech-carbon-estimator/node_modules/@angular/elements": {
+      "version": "20.3.15",
+      "resolved": "https://registry.npmjs.org/@angular/elements/-/elements-20.3.15.tgz",
+      "integrity": "sha512-+wjqUBprhrssXOCVA8R1TzsBvGQr5tvh5zvVYK/TAmrd1st2j0dywXkhxJrtyblumELiFSQfbIn7CMrMNTBR6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "20.3.15",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@scottlogic/tech-carbon-estimator/node_modules/@angular/forms": {
+      "version": "20.3.15",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.15.tgz",
+      "integrity": "sha512-gS5hQkinq52pm/7mxz4yHPCzEcmRWjtUkOVddPH0V1BW/HMni/p4Y6k2KqKBeGb9p8S5EAp6PDxDVLOPukp3mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "20.3.15",
+        "@angular/core": "20.3.15",
+        "@angular/platform-browser": "20.3.15",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@scottlogic/tech-carbon-estimator/node_modules/@angular/platform-browser": {
+      "version": "20.3.15",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.15.tgz",
+      "integrity": "sha512-TxRM/wTW/oGXv/3/Iohn58yWoiYXOaeEnxSasiGNS1qhbkcKtR70xzxW6NjChBUYAixz2ERkLURkpx3pI8Q6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/animations": "20.3.15",
+        "@angular/common": "20.3.15",
+        "@angular/core": "20.3.15"
+      },
+      "peerDependenciesMeta": {
+        "@angular/animations": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@scottlogic/tech-carbon-estimator/node_modules/@angular/platform-browser-dynamic": {
+      "version": "20.3.15",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.15.tgz",
+      "integrity": "sha512-RizuRdBt0d6ongQ2y8cr8YsXFyjF8f91vFfpSNw+cFj+oiEmRC1txcWUlH5bPLD9qSDied8qazUi0Tb8VPQDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "20.3.15",
+        "@angular/compiler": "20.3.15",
+        "@angular/core": "20.3.15",
+        "@angular/platform-browser": "20.3.15"
+      }
+    },
+    "node_modules/@scottlogic/tech-carbon-estimator/node_modules/@angular/router": {
+      "version": "20.3.15",
+      "resolved": "https://registry.npmjs.org/@angular/router/-/router-20.3.15.tgz",
+      "integrity": "sha512-6+qgk8swGSoAu7ISSY//GatAyCP36hEvvUgvjbZgkXLLH9yUQxdo77ij05aJ5s0OyB25q/JkqS8VTY0z1yE9NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "20.3.15",
+        "@angular/core": "20.3.15",
+        "@angular/platform-browser": "20.3.15",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@sinclair/typebox": {
@@ -5485,53 +5529,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
-      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.56.1"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.56.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
-      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "@scottlogic/tech-carbon-estimator": "^0.6.0",
+    "@scottlogic/tech-carbon-estimator": "^0.7.0",
     "@tailwindcss/typography": "^0.5.10",
     "@types/jest": "^29.5.14",
     "ajv": "^8.17.1",


### PR DESCRIPTION
This PR updates the @scottlogic/tech-carbon-estimator dependency from version 0.6.0 to 0.7.0, incorporating the latest features or fixes from the upstream package.

Key Changes:

    Bumped @scottlogic/tech-carbon-estimator from ^0.6.0 to ^0.7.0
